### PR TITLE
Take unique charset into account where needed

### DIFF
--- a/test/voucher_codes.spec.js
+++ b/test/voucher_codes.spec.js
@@ -111,6 +111,18 @@ describe('voucher_codes', function(){
         }).toThrow("Not possible to generate requested number of codes.");
     });
 
+    it('should detect infeasible config for charset with duplicates', function(){
+        var config = {
+            count: 2,
+            charset: "11",
+            length: 2
+        }; // there is only 1 possible code for this config
+
+        expect(function() {
+            voucher_codes.generate(config);
+        }).toThrow("Not possible to generate requested number of codes.");
+    });
+
     it('should generate fixed code', function(){
         var config = {
             count: 1,
@@ -199,6 +211,19 @@ describe('voucher_codes', function(){
         expect((voucher_codes.generate(config, 2703))[0]).toEqual("prefix-aZZ-postfix");
         expect((voucher_codes.generate(config, 2704))[0]).toEqual("prefix-baa-postfix");
         expect((voucher_codes.generate(config, 2705))[0]).toEqual("prefix-bab-postfix");
+    });
+
+    it('should generate series of sequential codes from charset with duplicates', function(){
+        var config = {
+            charset: "001",
+            pattern: "##",
+            count: 4
+        };
+
+        const codes = voucher_codes.generate(config, 0);
+
+        expect(codes.length).toEqual(4);
+        expect(codes).toEqual(["00", "01", "10", "11"]);
     });
 
 });

--- a/voucher_codes.js
+++ b/voucher_codes.js
@@ -39,7 +39,7 @@
         sequenceOffset = 12)  Math.floor(12 / Math.pow(10, 0)) % 10  ->  Math.floor(12 / 1) % 10   ->  2
     */
     function sequenceElem(config, sequenceOffset, charIndex) {
-        return config.charset[Math.floor(sequenceOffset / Math.pow(config.charset.length, config.length - charIndex - 1)) % config.charset.length];
+        return config.unique_charset[Math.floor(sequenceOffset / Math.pow(config.unique_charset.length, config.length - charIndex - 1)) % config.unique_charset.length];
     }
 
     function charset(name) {
@@ -64,6 +64,7 @@
         this.count = config.count || 1;
         this.length = config.length || 8;
         this.charset = config.charset || charset("alphanumeric");
+        this.unique_charset = uniqueCharset(this.charset);
         this.prefix = config.prefix || "";
         this.postfix = config.postfix || "";
         this.pattern = config.pattern || repeat("#", this.length);
@@ -71,6 +72,22 @@
         if (config.pattern) {
             this.length = (config.pattern.match(/#/g) || []).length;
         }
+    }
+
+    function uniqueCharset(charset) {
+        var map = {};
+        var result = [];
+
+        for (var i = 0; i < charset.length; i++) {
+            const sign = charset[i];
+
+            if (!map[sign]) {
+                result.push(sign);
+                map[sign] = true;
+            }
+        }
+
+        return result.join("");
     }
 
     function generateOne(config, sequenceOffset) {
@@ -90,7 +107,7 @@
     }
 
     function maxCombinationsCount (config) {
-        return Math.pow(config.charset.length, config.length);
+        return Math.pow(config.unique_charset.length, config.length);
     }
 
     function isFeasible(config) {
@@ -100,6 +117,7 @@
     function generate(config, sequenceOffset) {
         config = new Config(config);
         var count = config.count;
+
         if (!isFeasible(config)) {
             throw new Error("Not possible to generate requested number of codes.");
         }
@@ -114,16 +132,22 @@
             }
         }
 
-        var codes = {};
+        var map = {};
+        var codes = [];
+
         while (count > 0) {
             var code = generateOne(config, sequenceOffset);
-            if (codes[code] === undefined) {
-                codes[code] = true;
+
+            if (!map[code]) {
+                codes.push(code);
+                map[code] = true;
                 count--;
-                sequenceOffset++;
             }
+
+            sequenceOffset++;
         }
-        return Object.keys(codes);
+
+        return codes;
     }
 
     var voucher_codes = {


### PR DESCRIPTION
Summary:
- For charsets with duplicates:
  - fixing feasibility check
  - fixing sequence generation
- Additional fix for sequence generation - removing the randomness at the end of the flow
- Intentionally leaving the charset with possible duplicates in random codes generation to give the possibility to control the probability